### PR TITLE
CI setup with Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - 'v*.[0-9]'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install modules
+      run: yarn
+    - name: Run tests
+      run: yarn test


### PR DESCRIPTION
Adding CI setup with Github Actions.

* I noticed with other projects in this org, the github actions are also ran on branches with `version naming`, so I went ahead and added that as well.
* Since this project is just getting set up, i have commented the running test piece in the Github CI Action. Left a comment in there as well. We can uncomment it once we have other pieces like `package.json`

Validation:
* I went ahead and created a dummy PR within my fork to make the Github Actions run. 
* Below screenshots shows the successful run of the same.
<img width="1377" alt="tooltip-actions" src="https://user-images.githubusercontent.com/10603196/138732961-08a3203f-ec90-4565-8c0f-c9360a4b4fb5.png">

Resolves #4