### PR TITLE
#30 modify the sanitize method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -237,7 +237,10 @@ export default class Tooltip {
   */
   static get sanitize() {
     return {
-      span: true,
+      span: (e) => {
+        e.classList.remove('tooltip-tool__span', 'tooltip-tool__underline');
+        return { class: true, 'data-tooltip': true };
+      },
     };
   }
 }


### PR DESCRIPTION
Fix #30 
According to the documentation, the sanitize method was solved to saved only the class 'cdx-tooltip' and the data attribute called 'data-tooltip'. 

Resources:
https://github.com/guardian/html-janitor