### PR TITLE
Bump ossf/scorecard-action to v2.0.6

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@68bf5b3327e4fd443d2add8ab122280547b4a16d # v2.0.2
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.6
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Description

Fixes scorecard workflow which failed [here](https://github.com/kommitters/editorjs-tooltip/actions/runs/3333046579).

The solution is to update `ossf/scorecard-action` to v2.0.6.

More info:
https://github.com/ossf/scorecard-action/issues/997#issuecomment-1292952837

