### PR TITLE
Keep read-only permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   build:
-    permissions:
-      checks: write  # for coverallsapp/github-action to create new checks
-      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
     - name: Harden Runner


### PR DESCRIPTION
Keep read-only permissions in CI workflow

https://api.securityscorecards.dev/projects/github.com/kommitters/editorjs-tooltip
![image](https://user-images.githubusercontent.com/39246879/209826788-71de1410-cf37-49f2-a8d7-356fe15c6e32.png)
